### PR TITLE
Wrapper Script Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In the following `$repo` refers to this repository's root directory.
   Version `3.4.4` is known to work - other versions may work, too.
 
   This repository used to use `docker` - so it should be doable using `docker`, too.
-  Feel free to try and adapt the scripts accordingly.
+  If `podman` is not installed, `docker` will be tried as a fallback.
 - `Xilinx ISE` installer files\
   Due to licensing, the installer files are not shipped alongside this repository.
   Instead, please head over to [xilinx.com](https://www.xilinx.com/downloadNav/vivado-design-tools/archive-ise.html) and download the necessary files.

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/ubuntu:14.04
+FROM docker.io/ubuntu:14.04 as install
 
 # Locale - make sure en_US.UTF-8 is available and the default locale
 RUN locale-gen en_US.UTF-8 \
@@ -48,6 +48,10 @@ RUN tar -xvf /tmp/Xilinx_ISE_DS_14.7_1015_1-1.tar \
     && TERM=xterm /tmp/install.exp \
     && rm -rf /tmp/* \
     && mkdir -p /root/.Xilinx
+
+# Make another stage so the final image doesn't have the installer in the history
+FROM scratch AS run
+COPY --from=install / /
 
 COPY src/entrypoint.sh /usr/bin/
 WORKDIR /workspace

--- a/tools/xilinx.sh
+++ b/tools/xilinx.sh
@@ -60,7 +60,19 @@ fi
 
 shift $((OPTIND - 1))
 
-podman run \
+if which podman >/dev/null
+then
+    RUNNER=podman
+elif which docker >/dev/null
+then
+    RUNNER=docker
+else
+    echo "neither 'podman' nor 'docker' is available to run the container"
+    exit 1
+fi
+
+# Podman and Docker are drop-in compatible
+$RUNNER run \
     -it \
     --rm \
     --net=bridge \

--- a/tools/xilinx.sh
+++ b/tools/xilinx.sh
@@ -40,6 +40,12 @@ while getopts ":hl:p:-" option; do
     esac
 done
 
+if [ -z "$LICENSE_PATH" ] || [ -z "$PROJECT_DIR" ]
+then
+    help
+    exit 1
+fi
+
 if [ ! -f "$LICENSE_PATH" ]
 then
     echo "license file '$LICENSE_PATH' does not exist"

--- a/tools/xilinx.sh
+++ b/tools/xilinx.sh
@@ -76,8 +76,11 @@ $RUNNER run \
     -it \
     --rm \
     --net=bridge \
+    --user $(id -u) \
     -e DISPLAY=$DISPLAY \
+    -e HOME=/root \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -v $HOME/.Xauthority:/root/.Xauthority:rw \
     -v $LICENSE_PATH:/root/.Xilinx/Xilinx.lic:ro \
     -v $PROJECT_DIR:/workspace \
     xilinx-ise \


### PR DESCRIPTION
This will:

1. Print the help of you try and run the wrapper without its required options
2. Make the wrapper script attempt to use `docker` if it can't find `podman`; they basically use the same options.
3. Make X11 work (for me). It looked like it was intended to work, but it doesn't seem to actually be able to work without running the client as the right UID and passing through the authentication info. Unless people are meant to be turning off their X security somehow?